### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-bingo.computer


### PR DESCRIPTION
i have acquired the domain bingo.computer and would like to use it with github pages, which seems not possible because this repo already has a gh pages configuration for that domain :@)